### PR TITLE
Enhance booster system with configurable stacking and metadata

### DIFF
--- a/src/main/java/org/ledat/enchantMaterial/booster/Booster.java
+++ b/src/main/java/org/ledat/enchantMaterial/booster/Booster.java
@@ -75,7 +75,43 @@ public class Booster {
     public long getTimeLeftSeconds() {
         return getRemainingMillis() / 1000L;
     }
-    
+
+    public long getTotalDurationMillis() {
+        return Math.max(0L, endTime - startTime);
+    }
+
+    public long getTotalDurationSeconds() {
+        return getTotalDurationMillis() / 1000L;
+    }
+
+    public long getElapsedSeconds() {
+        return Math.max(0L, (System.currentTimeMillis() - startTime) / 1000L);
+    }
+
+    public Booster extendDuration(long additionalSeconds) {
+        if (additionalSeconds <= 0) {
+            throw new IllegalArgumentException("Thời gian cộng thêm phải lớn hơn 0");
+        }
+        long additionalMillis = additionalSeconds * 1000L;
+        long newEndTime = endTime + additionalMillis;
+        return new Booster(type, multiplier, startTime, newEndTime);
+    }
+
+    public Booster withMultiplier(double newMultiplier) {
+        if (newMultiplier <= 0) {
+            throw new IllegalArgumentException("Multiplier mới phải lớn hơn 0");
+        }
+        return new Booster(type, newMultiplier, startTime, endTime);
+    }
+
+    public double getRemainingRatio() {
+        long totalDuration = getTotalDurationMillis();
+        if (totalDuration <= 0) {
+            return 0.0;
+        }
+        return Math.max(0.0, Math.min(1.0, (double) getRemainingMillis() / totalDuration));
+    }
+
     public double getProgressPercentage() {
         long totalDuration = endTime - startTime;
         long elapsed = System.currentTimeMillis() - startTime;

--- a/src/main/java/org/ledat/enchantMaterial/booster/BoosterActivationResult.java
+++ b/src/main/java/org/ledat/enchantMaterial/booster/BoosterActivationResult.java
@@ -1,0 +1,178 @@
+package org.ledat.enchantMaterial.booster;
+
+import java.util.Objects;
+
+/**
+ * Kết quả khi xử lý một yêu cầu booster.
+ */
+public class BoosterActivationResult {
+
+    public enum Status {
+        CREATED,
+        EXTENDED,
+        REPLACED,
+        QUEUED
+    }
+
+    private final BoosterRequest request;
+    private final boolean success;
+    private final Status status;
+    private final Booster booster;
+    private final Booster previousBooster;
+    private final BoosterFailureReason failureReason;
+    private final long additionalDurationSeconds;
+    private final String message;
+
+    private BoosterActivationResult(Builder builder) {
+        this.request = builder.request;
+        this.success = builder.success;
+        this.status = builder.status;
+        this.booster = builder.booster;
+        this.previousBooster = builder.previousBooster;
+        this.failureReason = builder.failureReason;
+        this.additionalDurationSeconds = builder.additionalDurationSeconds;
+        this.message = builder.message;
+    }
+
+    public static BoosterActivationResult created(BoosterRequest request, Booster booster, String message) {
+        return new Builder(request, true)
+                .status(Status.CREATED)
+                .booster(booster)
+                .message(message)
+                .build();
+    }
+
+    public static BoosterActivationResult extended(BoosterRequest request, Booster booster,
+                                                   Booster previous, long additionalSeconds, String message) {
+        return new Builder(request, true)
+                .status(Status.EXTENDED)
+                .booster(booster)
+                .previousBooster(previous)
+                .additionalDurationSeconds(additionalSeconds)
+                .message(message)
+                .build();
+    }
+
+    public static BoosterActivationResult replaced(BoosterRequest request, Booster booster,
+                                                   Booster previous, String message) {
+        return new Builder(request, true)
+                .status(Status.REPLACED)
+                .booster(booster)
+                .previousBooster(previous)
+                .message(message)
+                .build();
+    }
+
+    public static BoosterActivationResult queued(BoosterRequest request, Booster booster, String message) {
+        return new Builder(request, true)
+                .status(Status.QUEUED)
+                .booster(booster)
+                .message(message)
+                .build();
+    }
+
+    public static BoosterActivationResult failure(BoosterRequest request, BoosterFailureReason reason, String message) {
+        return new Builder(request, false)
+                .failureReason(reason)
+                .message(message)
+                .build();
+    }
+
+    public BoosterRequest getRequest() {
+        return request;
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public Booster getBooster() {
+        return booster;
+    }
+
+    public Booster getPreviousBooster() {
+        return previousBooster;
+    }
+
+    public BoosterFailureReason getFailureReason() {
+        return failureReason;
+    }
+
+    public long getAdditionalDurationSeconds() {
+        return additionalDurationSeconds;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public boolean replacedExisting() {
+        return status == Status.REPLACED;
+    }
+
+    public boolean extendedExisting() {
+        return status == Status.EXTENDED;
+    }
+
+    public boolean createdNew() {
+        return status == Status.CREATED;
+    }
+
+    public boolean queuedBooster() {
+        return status == Status.QUEUED;
+    }
+
+    public static class Builder {
+        private final BoosterRequest request;
+        private final boolean success;
+        private Status status;
+        private Booster booster;
+        private Booster previousBooster;
+        private BoosterFailureReason failureReason;
+        private long additionalDurationSeconds;
+        private String message;
+
+        public Builder(BoosterRequest request, boolean success) {
+            this.request = Objects.requireNonNull(request, "request");
+            this.success = success;
+        }
+
+        public Builder status(Status status) {
+            this.status = status;
+            return this;
+        }
+
+        public Builder booster(Booster booster) {
+            this.booster = booster;
+            return this;
+        }
+
+        public Builder previousBooster(Booster previousBooster) {
+            this.previousBooster = previousBooster;
+            return this;
+        }
+
+        public Builder failureReason(BoosterFailureReason failureReason) {
+            this.failureReason = failureReason;
+            return this;
+        }
+
+        public Builder additionalDurationSeconds(long additionalDurationSeconds) {
+            this.additionalDurationSeconds = additionalDurationSeconds;
+            return this;
+        }
+
+        public Builder message(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public BoosterActivationResult build() {
+            return new BoosterActivationResult(this);
+        }
+    }
+}

--- a/src/main/java/org/ledat/enchantMaterial/booster/BoosterFailureReason.java
+++ b/src/main/java/org/ledat/enchantMaterial/booster/BoosterFailureReason.java
@@ -1,0 +1,26 @@
+package org.ledat.enchantMaterial.booster;
+
+/**
+ * Danh sách các lý do khiến booster không thể kích hoạt hoặc xử lý thành công.
+ */
+public enum BoosterFailureReason {
+    PLUGIN_SHUTTING_DOWN("Plugin đang tắt, không thể xử lý booster mới."),
+    PLAYER_OFFLINE("Người chơi không trực tuyến."),
+    INVALID_REQUEST("Dữ liệu booster không hợp lệ."),
+    INVALID_MULTIPLIER("Hệ số nhân không hợp lệ."),
+    INVALID_DURATION("Thời lượng booster không hợp lệ."),
+    LIMIT_REACHED("Người chơi đã đạt giới hạn booster."),
+    DUPLICATE_TYPE("Người chơi đã có booster loại này."),
+    WEAKER_THAN_CURRENT("Booster mới yếu hơn booster hiện tại."),
+    INTERNAL_ERROR("Đã xảy ra lỗi nội bộ.");
+
+    private final String defaultMessage;
+
+    BoosterFailureReason(String defaultMessage) {
+        this.defaultMessage = defaultMessage;
+    }
+
+    public String getDefaultMessage() {
+        return defaultMessage;
+    }
+}

--- a/src/main/java/org/ledat/enchantMaterial/booster/BoosterRequest.java
+++ b/src/main/java/org/ledat/enchantMaterial/booster/BoosterRequest.java
@@ -1,0 +1,204 @@
+package org.ledat.enchantMaterial.booster;
+
+import java.util.Objects;
+
+/**
+ * Đại diện cho một yêu cầu kích hoạt hoặc thao tác booster.
+ */
+public class BoosterRequest {
+    private final BoosterType type;
+    private final double multiplier;
+    private final long durationSeconds;
+    private final BoosterStackingStrategy stackingStrategy;
+    private final BoosterSource source;
+    private final String note;
+    private final boolean bypassLimit;
+    private final boolean bypassValidation;
+    private final boolean silent;
+    private final boolean saveToStorage;
+    private final Booster customBooster;
+
+    private BoosterRequest(Builder builder) {
+        this.type = Objects.requireNonNull(builder.type, "type");
+        this.multiplier = builder.multiplier;
+        this.durationSeconds = builder.durationSeconds;
+        this.stackingStrategy = builder.stackingStrategy;
+        this.source = builder.source;
+        this.note = builder.note;
+        this.bypassLimit = builder.bypassLimit;
+        this.bypassValidation = builder.bypassValidation;
+        this.silent = builder.silent;
+        this.saveToStorage = builder.saveToStorage;
+        this.customBooster = builder.customBooster;
+
+        if (this.customBooster == null) {
+            if (this.multiplier <= 0) {
+                throw new IllegalArgumentException("Multiplier phải lớn hơn 0");
+            }
+            if (this.durationSeconds <= 0) {
+                throw new IllegalArgumentException("Duration phải lớn hơn 0");
+            }
+        }
+    }
+
+    public BoosterType getType() {
+        return type;
+    }
+
+    public double getMultiplier() {
+        return multiplier;
+    }
+
+    public long getDurationSeconds() {
+        return durationSeconds;
+    }
+
+    public BoosterStackingStrategy getStackingStrategy() {
+        return stackingStrategy;
+    }
+
+    public BoosterSource getSource() {
+        return source;
+    }
+
+    public String getNote() {
+        return note;
+    }
+
+    public boolean isBypassLimit() {
+        return bypassLimit;
+    }
+
+    public boolean isBypassValidation() {
+        return bypassValidation;
+    }
+
+    public boolean isSilent() {
+        return silent;
+    }
+
+    public boolean isSaveToStorage() {
+        return saveToStorage;
+    }
+
+    public boolean hasCustomBooster() {
+        return customBooster != null;
+    }
+
+    public Booster getCustomBooster() {
+        return customBooster;
+    }
+
+    public BoosterRequest withCustomBooster(Booster booster) {
+        return toBuilder()
+                .customBooster(booster)
+                .multiplier(booster.getMultiplier())
+                .durationSeconds(Math.max(1L, booster.getTotalDurationMillis() / 1000L))
+                .build();
+    }
+
+    public Builder toBuilder() {
+        return new Builder(this);
+    }
+
+    public static Builder builder(BoosterType type) {
+        return new Builder(type);
+    }
+
+    public static BoosterRequest fromExistingBooster(Booster booster, BoosterSource source) {
+        return BoosterRequest.builder(booster.getType())
+                .multiplier(booster.getMultiplier())
+                .durationSeconds(Math.max(1L, booster.getTotalDurationMillis() / 1000L))
+                .source(source)
+                .customBooster(booster)
+                .saveToStorage(false)
+                .stackingStrategy(BoosterStackingStrategy.SMART)
+                .build();
+    }
+
+    public static class Builder {
+        private final BoosterType type;
+        private double multiplier;
+        private long durationSeconds;
+        private BoosterStackingStrategy stackingStrategy = BoosterStackingStrategy.SMART;
+        private BoosterSource source = BoosterSource.UNKNOWN;
+        private String note;
+        private boolean bypassLimit;
+        private boolean bypassValidation;
+        private boolean silent;
+        private boolean saveToStorage = true;
+        private Booster customBooster;
+
+        private Builder(BoosterType type) {
+            this.type = Objects.requireNonNull(type, "type");
+        }
+
+        private Builder(BoosterRequest request) {
+            this.type = request.type;
+            this.multiplier = request.multiplier;
+            this.durationSeconds = request.durationSeconds;
+            this.stackingStrategy = request.stackingStrategy;
+            this.source = request.source;
+            this.note = request.note;
+            this.bypassLimit = request.bypassLimit;
+            this.bypassValidation = request.bypassValidation;
+            this.silent = request.silent;
+            this.saveToStorage = request.saveToStorage;
+            this.customBooster = request.customBooster;
+        }
+
+        public Builder multiplier(double multiplier) {
+            this.multiplier = multiplier;
+            return this;
+        }
+
+        public Builder durationSeconds(long durationSeconds) {
+            this.durationSeconds = durationSeconds;
+            return this;
+        }
+
+        public Builder stackingStrategy(BoosterStackingStrategy stackingStrategy) {
+            this.stackingStrategy = stackingStrategy;
+            return this;
+        }
+
+        public Builder source(BoosterSource source) {
+            this.source = source;
+            return this;
+        }
+
+        public Builder note(String note) {
+            this.note = note;
+            return this;
+        }
+
+        public Builder bypassLimit(boolean bypassLimit) {
+            this.bypassLimit = bypassLimit;
+            return this;
+        }
+
+        public Builder bypassValidation(boolean bypassValidation) {
+            this.bypassValidation = bypassValidation;
+            return this;
+        }
+
+        public Builder silent(boolean silent) {
+            this.silent = silent;
+            return this;
+        }
+
+        public Builder saveToStorage(boolean saveToStorage) {
+            this.saveToStorage = saveToStorage;
+            return this;
+        }
+
+        public Builder customBooster(Booster customBooster) {
+            this.customBooster = customBooster;
+            return this;
+        }
+
+        public BoosterRequest build() {
+            return new BoosterRequest(this);
+        }
+    }
+}

--- a/src/main/java/org/ledat/enchantMaterial/booster/BoosterSource.java
+++ b/src/main/java/org/ledat/enchantMaterial/booster/BoosterSource.java
@@ -1,0 +1,25 @@
+package org.ledat.enchantMaterial.booster;
+
+/**
+ * Đại diện cho nguồn gốc của một booster để phục vụ mục đích hiển thị và logging.
+ */
+public enum BoosterSource {
+    ADMIN_COMMAND("Lệnh quản trị"),
+    REWARD_SYSTEM("Phần thưởng"),
+    GLOBAL_EVENT("Sự kiện toàn server"),
+    PLAYER_PURCHASE("Cửa hàng"),
+    PERSISTED("Khôi phục"),
+    LEGACY("Kế thừa"),
+    API("Từ API"),
+    UNKNOWN("Không rõ");
+
+    private final String displayName;
+
+    BoosterSource(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/src/main/java/org/ledat/enchantMaterial/booster/BoosterStackingStrategy.java
+++ b/src/main/java/org/ledat/enchantMaterial/booster/BoosterStackingStrategy.java
@@ -1,0 +1,69 @@
+package org.ledat.enchantMaterial.booster;
+
+import java.util.Locale;
+
+/**
+ * Xác định cách xử lý khi người chơi đã có booster cùng loại.
+ */
+public enum BoosterStackingStrategy {
+    /**
+     * Từ chối booster mới nếu đã có booster cùng loại.
+     */
+    REJECT_DUPLICATES("Giữ nguyên", "Không cho phép booster trùng loại"),
+
+    /**
+     * Thay thế booster hiện tại nếu booster mới mạnh hơn.
+     */
+    REPLACE_IF_STRONGER("Thay thế", "Chỉ thay thế khi booster mới mạnh hơn"),
+
+    /**
+     * Cộng dồn thời gian cho booster hiện tại.
+     */
+    EXTEND_DURATION("Cộng dồn", "Cộng thêm thời gian vào booster hiện có"),
+
+    /**
+     * Chiến lược thông minh: mạnh hơn thì thay, bằng nhau thì cộng thời gian, yếu hơn thì từ chối.
+     */
+    SMART("Thông minh", "Tự động quyết định tùy theo booster hiện tại");
+
+    private final String displayName;
+    private final String description;
+
+    BoosterStackingStrategy(String displayName, String description) {
+        this.displayName = displayName;
+        this.description = description;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public static BoosterStackingStrategy fromString(String input) {
+        if (input == null || input.isBlank()) {
+            return SMART;
+        }
+
+        String normalized = input.trim().toUpperCase(Locale.ROOT);
+        switch (normalized) {
+            case "STRICT":
+            case "REJECT":
+            case "NONE":
+                return REJECT_DUPLICATES;
+            case "REPLACE":
+            case "OVERRIDE":
+            case "OVERWRITE":
+                return REPLACE_IF_STRONGER;
+            case "EXTEND":
+            case "STACK":
+            case "ADD":
+                return EXTEND_DURATION;
+            case "SMART":
+            default:
+                return SMART;
+        }
+    }
+}

--- a/src/main/resources/booster.yml
+++ b/src/main/resources/booster.yml
@@ -1,5 +1,6 @@
 settings:
   max-per-player: 2
+  default-stack-strategy: SMART
 
 bossbar:
   show-bossbar: true
@@ -11,3 +12,6 @@ bossbar:
     title: "&bBooster 1: &f%type1% x%multiplier1% &7(%time1%) &8| &aBooster 2: &f%type2% x%multiplier2% &7(%time2%)"
     color: BLUE
     style: SEGMENTED_20
+  multi:
+    title: "&bBooster 1: &f%type1% x%multiplier1% &7(%time1%) &8| &aBooster 2: &f%type2% x%multiplier2% &7(%time2%)%more%"
+    more-format: " &7(+%count% booster khác)"


### PR DESCRIPTION
## Summary
- introduce BoosterRequest, BoosterActivationResult and stacking strategy handling so booster activations can extend, replace or reject existing boosters with detailed metadata
- persist and expose booster metadata in bossbars, detailed info and listings while tightening storage and duration calculations
- extend booster commands to choose stacking modes, surface metadata in listings and document new default stack strategy config

## Testing
- `gradle build` *(fails: dependency repository returned HTTP 503 when resolving placeholderapi and VaultAPI)*

------
https://chatgpt.com/codex/tasks/task_b_68c939b68a90832bae61e18d81f45d74