### PR TITLE
Refactor player data access to use cache-first async flow

### DIFF
--- a/src/main/java/org/ledat/enchantMaterial/EnchantMaterial.java
+++ b/src/main/java/org/ledat/enchantMaterial/EnchantMaterial.java
@@ -347,21 +347,23 @@ public class EnchantMaterial extends JavaPlugin {
 
     // Thêm phương thức để lấy dữ liệu từ cache/pending
     public double getCurrentPoints(Player player) {
-        try {
-            return DatabaseManager.getPlayerDataAsync(player.getUniqueId()).get().getPoints();
-        } catch (Exception e) {
-            getLogger().warning("❌ Lỗi lấy points: " + e.getMessage());
-            return 0.0;
+        UUID uuid = player.getUniqueId();
+        boolean hasCache = DatabaseManager.getCached(uuid) != null;
+        PlayerData data = DatabaseManager.getPlayerDataCachedOrAsync(uuid, null);
+        if (!hasCache) {
+            getLogger().finer("Points cache miss cho " + player.getName() + ", dùng mặc định tạm thời");
         }
+        return data.getPoints();
     }
 
     public int getCurrentLevel(Player player) {
-        try {
-            return DatabaseManager.getPlayerDataAsync(player.getUniqueId()).get().getLevel();
-        } catch (Exception e) {
-            getLogger().warning("❌ Lỗi lấy level: " + e.getMessage());
-            return 1;
+        UUID uuid = player.getUniqueId();
+        boolean hasCache = DatabaseManager.getCached(uuid) != null;
+        PlayerData data = DatabaseManager.getPlayerDataCachedOrAsync(uuid, null);
+        if (!hasCache) {
+            getLogger().finer("Level cache miss cho " + player.getName() + ", dùng mặc định tạm thời");
         }
+        return data.getLevel();
     }
 
     private void hookBaoVePvP() {

--- a/src/main/java/org/ledat/enchantMaterial/EnchantMaterialPlaceholder.java
+++ b/src/main/java/org/ledat/enchantMaterial/EnchantMaterialPlaceholder.java
@@ -147,7 +147,7 @@ public class EnchantMaterialPlaceholder extends PlaceholderExpansion {
             // Rebirth placeholders
             case "rebirth_level": {
                 try {
-                    RebirthData rebirthData = DatabaseManager.getRebirthData(uuid);
+                    RebirthData rebirthData = DatabaseManager.getRebirthDataCachedOrAsync(uuid, null);
                     return String.valueOf(rebirthData.getRebirthLevel());
                 } catch (Exception e) {
                     return "0";
@@ -156,7 +156,7 @@ public class EnchantMaterialPlaceholder extends PlaceholderExpansion {
             
             case "rebirth_next_level": {
                 try {
-                    RebirthData rebirthData = DatabaseManager.getRebirthData(uuid);
+                    RebirthData rebirthData = DatabaseManager.getRebirthDataCachedOrAsync(uuid, null);
                     RebirthManager rebirthManager = plugin.getRebirthManager();
                     int maxLevel = rebirthManager.getConfig().getInt("rebirth.rebirth.max-level", 10);
                     int currentLevel = rebirthData.getRebirthLevel();
@@ -177,7 +177,7 @@ public class EnchantMaterialPlaceholder extends PlaceholderExpansion {
             
             case "rebirth_last_time": {
                 try {
-                    RebirthData rebirthData = DatabaseManager.getRebirthData(uuid);
+                    RebirthData rebirthData = DatabaseManager.getRebirthDataCachedOrAsync(uuid, null);
                     long lastTime = rebirthData.getLastRebirthTime();
                     if (lastTime == 0) return "Chưa từng chuyển sinh";
                     SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss");
@@ -190,10 +190,10 @@ public class EnchantMaterialPlaceholder extends PlaceholderExpansion {
             case "rebirth_can_rebirth": {
                 try {
                     if (player.getPlayer() == null) return "false";
-                    RebirthData rebirthData = DatabaseManager.getRebirthData(uuid);
+                    RebirthData rebirthData = DatabaseManager.getRebirthDataCachedOrAsync(uuid, null);
                     RebirthManager rebirthManager = plugin.getRebirthManager();
                     int nextLevel = rebirthData.getRebirthLevel() + 1;
-                    return String.valueOf(rebirthManager.canRebirth(player.getPlayer(), nextLevel));
+                    return String.valueOf(rebirthManager.canRebirthWithDebug(player.getPlayer(), nextLevel));
                 } catch (Exception e) {
                     return "false";
                 }
@@ -201,7 +201,7 @@ public class EnchantMaterialPlaceholder extends PlaceholderExpansion {
             
             case "rebirth_required_level": {
                 try {
-                    RebirthData rebirthData = DatabaseManager.getRebirthData(uuid);
+                    RebirthData rebirthData = DatabaseManager.getRebirthDataCachedOrAsync(uuid, null);
                     RebirthManager rebirthManager = plugin.getRebirthManager();
                     int nextLevel = rebirthData.getRebirthLevel() + 1;
                     String path = "rebirth.rebirth.levels." + nextLevel + ".required-level";
@@ -213,7 +213,7 @@ public class EnchantMaterialPlaceholder extends PlaceholderExpansion {
             
             case "rebirth_required_money": {
                 try {
-                    RebirthData rebirthData = DatabaseManager.getRebirthData(uuid);
+                    RebirthData rebirthData = DatabaseManager.getRebirthDataCachedOrAsync(uuid, null);
                     RebirthManager rebirthManager = plugin.getRebirthManager();
                     int nextLevel = rebirthData.getRebirthLevel() + 1;
                     String path = "rebirth.rebirth.levels." + nextLevel + ".required-money";
@@ -226,7 +226,7 @@ public class EnchantMaterialPlaceholder extends PlaceholderExpansion {
             
             case "rebirth_success_rate": {
                 try {
-                    RebirthData rebirthData = DatabaseManager.getRebirthData(uuid);
+                    RebirthData rebirthData = DatabaseManager.getRebirthDataCachedOrAsync(uuid, null);
                     RebirthManager rebirthManager = plugin.getRebirthManager();
                     int nextLevel = rebirthData.getRebirthLevel() + 1;
                     String path = "rebirth.rebirth.levels." + nextLevel + ".success-rate";
@@ -239,7 +239,7 @@ public class EnchantMaterialPlaceholder extends PlaceholderExpansion {
             
             case "rebirth_progress": {
                 try {
-                    RebirthData rebirthData = DatabaseManager.getRebirthData(uuid);
+                    RebirthData rebirthData = DatabaseManager.getRebirthDataCachedOrAsync(uuid, null);
                     RebirthManager rebirthManager = plugin.getRebirthManager();
                     int maxLevel = rebirthManager.getConfig().getInt("rebirth.rebirth.max-level", 10);
                     int currentLevel = rebirthData.getRebirthLevel();
@@ -251,7 +251,7 @@ public class EnchantMaterialPlaceholder extends PlaceholderExpansion {
             
             case "rebirth_progress_percent": {
                 try {
-                    RebirthData rebirthData = DatabaseManager.getRebirthData(uuid);
+                    RebirthData rebirthData = DatabaseManager.getRebirthDataCachedOrAsync(uuid, null);
                     RebirthManager rebirthManager = plugin.getRebirthManager();
                     int maxLevel = rebirthManager.getConfig().getInt("rebirth.rebirth.max-level", 10);
                     int currentLevel = rebirthData.getRebirthLevel();
@@ -264,7 +264,7 @@ public class EnchantMaterialPlaceholder extends PlaceholderExpansion {
             
             case "rebirth_progress_bar": {
                 try {
-                    RebirthData rebirthData = DatabaseManager.getRebirthData(uuid);
+                    RebirthData rebirthData = DatabaseManager.getRebirthDataCachedOrAsync(uuid, null);
                     RebirthManager rebirthManager = plugin.getRebirthManager();
                     int maxLevel = rebirthManager.getConfig().getInt("rebirth.rebirth.max-level", 10);
                     int currentLevel = rebirthData.getRebirthLevel();

--- a/src/main/java/org/ledat/enchantMaterial/gui/RebirthGUI.java
+++ b/src/main/java/org/ledat/enchantMaterial/gui/RebirthGUI.java
@@ -51,8 +51,8 @@ public class RebirthGUI implements Listener {
             // ✅ Load dữ liệu async và update GUI sau
             CompletableFuture.supplyAsync(() -> {
                 try {
-                    RebirthData rebirthData = DatabaseManager.getRebirthData(player.getUniqueId());
-                    PlayerData playerData = DatabaseManager.getPlayerDataAsync(player.getUniqueId()).get();
+                    RebirthData rebirthData = DatabaseManager.getRebirthDataCachedOrAsync(player.getUniqueId());
+                    PlayerData playerData = DatabaseManager.getPlayerDataCachedOrAsync(player.getUniqueId(), null);
                     return new Object[]{rebirthData, playerData};
                 } catch (Exception e) {
                     plugin.getLogger().severe("Lỗi load dữ liệu rebirth cho " + player.getName() + ": " + e.getMessage());
@@ -123,8 +123,8 @@ public class RebirthGUI implements Listener {
     // Phương thức fillGUIFromConfig với 2 tham số (giữ nguyên để tương thích)
     private void fillGUIFromConfig(Inventory gui, Player player) {
         try {
-            RebirthData rebirthData = DatabaseManager.getRebirthData(player.getUniqueId());
-            PlayerData playerData = DatabaseManager.getPlayerDataAsync(player.getUniqueId()).get();
+            RebirthData rebirthData = DatabaseManager.getRebirthDataCachedOrAsync(player.getUniqueId());
+            PlayerData playerData = DatabaseManager.getPlayerDataCachedOrAsync(player.getUniqueId(), null);
             
             // Gọi phương thức với 4 tham số
             fillGUIFromConfig(gui, player, rebirthData, playerData);
@@ -567,7 +567,7 @@ public class RebirthGUI implements Listener {
     private String replacePlaceholders(String text, Player player, Integer level) {
         try {
             PlayerData playerData = DatabaseManager.getPlayerData(player.getUniqueId().toString());
-            RebirthData rebirthData = DatabaseManager.getRebirthData(player.getUniqueId());
+            RebirthData rebirthData = DatabaseManager.getRebirthDataCachedOrAsync(player.getUniqueId());
             
             text = text.replace("%player%", player.getName())
                       .replace("%current_level%", String.valueOf(playerData.getLevel()))
@@ -634,7 +634,7 @@ public class RebirthGUI implements Listener {
                 int level = rebirthManager.getConfig().getInt(path + ".level", 1);
                 
                 try {
-                    RebirthData rebirthData = DatabaseManager.getRebirthData(player.getUniqueId());
+                    RebirthData rebirthData = DatabaseManager.getRebirthDataCachedOrAsync(player.getUniqueId());
                     
                     // Check if this is the next available rebirth level
                     if (level == rebirthData.getRebirthLevel() + 1) {
@@ -761,7 +761,7 @@ public class RebirthGUI implements Listener {
             // SỬA: Đường dẫn config đúng
             String path = "rebirth.rebirth.levels." + level;
             PlayerData playerData = DatabaseManager.getPlayerData(player.getUniqueId().toString());
-            RebirthData rebirthData = DatabaseManager.getRebirthData(player.getUniqueId());
+            RebirthData rebirthData = DatabaseManager.getRebirthDataCachedOrAsync(player.getUniqueId());
         
             // Kiểm tra level chuyển sinh
             if (rebirthData.getRebirthLevel() + 1 != level) {


### PR DESCRIPTION
## Summary
- add cache-aware helpers in `DatabaseManager` for player and rebirth data and reuse them across the plugin
- update commands, block listener, and placeholder handling to avoid blocking the main thread and respond via scheduled callbacks
- rework rebirth checks and penalties to operate on cached data and log when defaults are used

## Testing
- `./gradlew build` *(fails: Gradle wrapper JAR missing in repository)*

------
https://chatgpt.com/codex/tasks/task_b_68ca640a7c88832b8dc6ad29b1771b23