### PR TITLE
Add overload for cached rebirth data lookup

### DIFF
--- a/src/main/java/org/ledat/enchantMaterial/DatabaseManager.java
+++ b/src/main/java/org/ledat/enchantMaterial/DatabaseManager.java
@@ -443,6 +443,10 @@ public class DatabaseManager {
         });
     }
 
+    public static RebirthData getRebirthDataCachedOrAsync(UUID uuid) {
+        return getRebirthDataCachedOrAsync(uuid, null);
+    }
+
     public static RebirthData getRebirthDataCachedOrAsync(UUID uuid, Consumer<RebirthData> callback) {
         RebirthData cached = rebirthDataCache.get(uuid);
         Long ts = rebirthCacheTimestamps.get(uuid);


### PR DESCRIPTION
## Summary
- add a convenience overload of DatabaseManager#getRebirthDataCachedOrAsync that defaults the callback to null

## Testing
- ./gradlew test *(fails: Gradle wrapper JAR is missing from repository)*

------
https://chatgpt.com/codex/tasks/task_b_68ca79d24db0832bbacb338e4e539483